### PR TITLE
Fixed EOL bug when \r is used

### DIFF
--- a/source/Program.cs
+++ b/source/Program.cs
@@ -280,7 +280,24 @@ namespace TTSLuaExtractor
                     break;
                 }
 
-                int firstIncludeIndexEOL = lua.IndexOf("\n", firstIncludeIndex);
+                int firstIncludeIndexEOLN = lua.IndexOf("\n", firstIncludeIndex);
+                int firstIncludeIndexEOLR = lua.IndexOf("\r", firstIncludeIndex);
+
+                int firstIncludeIndexEOL;
+
+                if (firstIncludeIndexEOLN == -1 && firstIncludeIndexEOLR != -1)
+                {
+                    firstIncludeIndexEOL = firstIncludeIndexEOLR;
+                }
+                else if (firstIncludeIndexEOLR == -1 && firstIncludeIndexEOLN != -1)
+                {
+                    firstIncludeIndexEOL = firstIncludeIndexEOLN;
+                }
+                else
+                {
+                    firstIncludeIndexEOL = Math.Min(firstIncludeIndexEOLR, firstIncludeIndexEOLN);
+                }
+
                 if (firstIncludeIndexEOL == -1)
                 {
                     break;


### PR DESCRIPTION
This code was really helpful, thanks! The only problem I had was one of the scripts had an #include that ended in \r\n, so then it was searching for \r at the end, which didn't exist. I edited the code to look for either and take the earliest index in an attempt to cover any situation related to this problem.